### PR TITLE
fix(ci): add condition for dependency-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       upload-coverage-artifact: true
 
   dependency-review:
+    if: ${{ github.event_name == 'pull_request'}}
     uses: ./.github/workflows/dependency-review.yml
     with:
       fail-on-severity: moderate


### PR DESCRIPTION
The dependency-check action expects to be run on pull requests by default, so disabling it if action is not due to a PR.